### PR TITLE
Upgrade Regenerator to ~v0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "regenerator": "~0.1.7"
+    "regenerator": "~0.2.1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
The original motivation for the minor version bump was that `bin/regenerate` was renamed to `bin/regenerator`, but upgrading also makes other recent/future improvements available to grunt-regenerator users.
